### PR TITLE
Message ID randomnesss was not sufficient

### DIFF
--- a/messageid_test.go
+++ b/messageid_test.go
@@ -1,19 +1,21 @@
 package smtpd_test
 
 import (
+	"fmt"
 	"github.com/ruffrey/smtpd"
-	"math/rand"
 	"testing"
-	"time"
 )
 
 func Test_MessageID(t *testing.T) {
 	t.Run("NewMessageID is unlikely to collide", func(t *testing.T) {
-		rand.Seed(time.Now().UnixNano())
+		smtpd.InitPseudoRandomNumberGeneratorFallback()
 		o := make(map[string]bool)
 		var id string
 		for i := 0; i < 1000000; i++ {
 			id = smtpd.NewMessageID()
+			if i % 500000 == 0 {
+				fmt.Println("NewMessageID test: ", id)
+			}
 			if o[id] {
 				t.Errorf("Got duplicate unique id %d (%s)", i, id)
 				t.FailNow()

--- a/messageids.go
+++ b/messageids.go
@@ -1,0 +1,61 @@
+package smtpd
+
+import (
+	cryptoRand "crypto/rand"
+	"encoding/base64"
+	"math/rand"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const _charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+var charIndexes = len(_charset) - 1
+var _counter = 0
+var charmux sync.Mutex
+
+// when crypto source is exhausted, fallback to PRNG, which must have a unique seed
+func InitPseudoRandomNumberGeneratorFallback() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func getCounter() string {
+	charmux.Lock()
+	_counter++
+	if _counter > charIndexes {
+		_counter = 0
+	}
+	charmux.Unlock()
+	return string(_charset[_counter])
+}
+
+func randomInt(min, max int) int64 {
+	return int64(rand.Intn(max-min) + min)
+}
+
+// NewMessageID generates a message ID, but make sure to seed the random number
+// generator. It follows the Mailsac makeId pattern.
+func NewMessageID() string {
+	idLength := randomInt(13, 18)
+	dateEntropy := strconv.FormatInt((time.Now().UnixNano()/int64(time.Millisecond))+idLength, 36)[4:]
+	var randomPart []byte
+	key := make([]byte, idLength)
+	_, err := cryptoRand.Read(key[:])
+	if err == nil {
+		randomPart = key
+	} else {
+		// fallback to non-crypto random
+		fallback := make([]byte, idLength)
+		for i := range fallback {
+			fallback[i] = _charset[rand.Intn(charIndexes)]
+		}
+		randomPart = fallback
+	}
+	randString := strings.Replace(base64.URLEncoding.EncodeToString(randomPart), "=", "", -1)
+	// allow underscore as only special char, otherwise replace with a pseudo-rand char
+	randString = strings.Replace(randString, "-", getCounter(), -1)
+	randString = strings.Replace(randString, "/", getCounter(), -1)
+	return dateEntropy + getCounter() + randString + getCounter()
+}

--- a/server.go
+++ b/server.go
@@ -90,6 +90,7 @@ func NewServer(handler func(*Message) error) *Server {
 
 // NewServerWithLogger creates a server with a customer logger
 func NewServerWithLogger(handler func(*Message) error, logger *log.Logger) *Server {
+	InitPseudoRandomNumberGeneratorFallback()
 	name, err := os.Hostname()
 	if err != nil {
 		name = "localhost"


### PR DESCRIPTION
1. Moves the message ID generation to its own file.
2. PRIMARY ISSUE probably: Under heavy load, if crypto random source is exhausted, a psuedo-rand source is used. But the pseudo-random source was never initialized
with a new seed, so it would be using the same seed across all inbound
instances. This will use the unix nano time now, which should be different
even if the instances were deployed at almost the same time. It is initialized now
via the NewServer func.
3. Rather than replace the non-alphanumeric chars in the base64 version
of the message ID with predetermined ones, use a pseudo-random character.
4. Allow underscore in ids as one more piece of randomness.
5. Increase ID length

https://github.com/ruffrey/mailsac-private/issues/470
